### PR TITLE
Add minimal Next.js todo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# codex_test
+# Next.js Todo App
+
+This repository contains a minimal example of a to-do list application built with Next.js.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The app will be available at `http://localhost:3000`.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "todo-next-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+
+export default function Home() {
+  const [items, setItems] = useState([])
+  const [text, setText] = useState('')
+
+  const addItem = () => {
+    const value = text.trim()
+    if (!value) return
+    setItems([...items, value])
+    setText('')
+  }
+
+  const removeItem = (index) => {
+    setItems(items.filter((_, i) => i !== index))
+  }
+
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>Todo List</h1>
+      <input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="Add todo"
+      />
+      <button onClick={addItem}>Add</button>
+      <ul>
+        {items.map((item, index) => (
+          <li key={index}>
+            {item} <button onClick={() => removeItem(index)}>x</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- initialize package.json for Next.js
- add todo list page in `pages/index.js`
- add basic next config
- update README with instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68627abbdcc8832cae49ea8ee2d16754